### PR TITLE
Passage de la série à 115200 bps

### DIFF
--- a/asserv/main/Main.cpp
+++ b/asserv/main/Main.cpp
@@ -18,10 +18,8 @@ Serial pc(USBTX, USBRX);
 
 int main()
 {
-    pc.baud(230400);
-    // Initialisation du port série par défaut (utilisé par printf & co)
-/*    serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
-    serial_baud(&stdio_uart, 230400); // GaG va être content*/
+    // Initialisation du port série sur USB (utilisé par printf & co)
+    pc.baud(115200);
 
     printf("--- Asservissement Nancyborg ---\r\n");
     printf("Version " GIT_VERSION " - Compilée le " DATE_COMPIL " par " AUTEUR_COMPIL "\r\n\r\n");


### PR DESCRIPTION
Le buffer UART de la mbed fait 16 octets, donc ça ne sert à rien
d'aller trop vite. L'IA va juste le remplir et on va perdre des paquets.
L'IA *devrait* aussi limiter le nombre de consigne envoyées en même temps,
pour être sûr qu'on a le temps de tout dépiler

Tant qu'à y être, on vire aussi du code commenté...